### PR TITLE
Improve the stylus stylesheet

### DIFF
--- a/template/avatar.styl
+++ b/template/avatar.styl
@@ -1,21 +1,17 @@
+@import "nib"
+
 .avatar
   height 40px
   width 40px
-  background-size 40px 40px
+  background-size 100% 100%
   display block
-  &.circle
-    -moz-border-radius 40px
-    -webkit-border-radius 40px
-    border-radius 40px
+
   &.rounded
-    -moz-border-radius 5px
-    -webkit-border-radius 5px
-    border-radius 5px      
+    border-radius 5px
+
+  &.circle
+    border-radius 50%
+
   &.large
     height 80px
     width 80px
-    background-size 80px 80px
-    &.circle
-      -moz-border-radius 80px
-      -webkit-border-radius 80px
-      border-radius 80px


### PR DESCRIPTION
- Use `nib` to autoprefix properties
- Use percentage values for `.circle` `border-radius` and for `background-size`, so it works at any size
