### PR TITLE
Add option to pass in default gravatar parameters

### DIFF
--- a/export.js
+++ b/export.js
@@ -13,24 +13,25 @@ Avatar = {
     // path (e.g. '/images/defaultAvatar.png')
     defaultAvatarUrl: '',
 
-    // Any additional parameters for the standard gravatar. Options are available
-    // at https://secure.gravatar.com/site/implement/images/#default-image
-    // Default avatar url can also be passed in this way: { default: 'url-here' }
-    // example: { d: 'identicon', r: 'pg', f: 'y' }
-    defaultAvatarParams: {}
+    // Gravatar image type to use. Options are available at 
+    // https://secure.gravatar.com/site/implement/images/#default-image
+    gravatarDefault: ''
   },
 
   // Get the url of the user's avatar
   getUrl: function (user) {
     
-    var url, defaultUrl;
+    var url, defaultUrl, gravatarDefault;
+    var validGravatars = ['404', 'mm', 'identicon', 'monsterid', 'wavatar', 'retro', 'blank'];
 
+    if (_.contains(validGravatars, Avatar.options.gravatarDefault))
+      gravatarDefault = Avatar.options.gravatarDefault;
+    
     defaultUrl = Avatar.options.defaultAvatarUrl || '/packages/bengott_avatar/default.png';
 
     // If it's a relative path, complete the URL (prepend the origin)
-    if (defaultUrl.charAt(0) === '/' && defaultUrl.charAt(1) !== '/') {
+    if (defaultUrl.charAt(0) === '/' && defaultUrl.charAt(1) !== '/')
       defaultUrl = location.origin + defaultUrl;
-    }
 
     if (user) {
       var svc = getService(user);
@@ -57,17 +58,10 @@ Avatar = {
         // using either the standard default URL or a custom defaultAvatarUrl
         // that is a relative path (e.g. '/images/defaultAvatar.png').
         var options = {
+          default: gravatarDefault || defaultUrl,
           size: 200, // use 200x200 like twitter and facebook above (might be useful later)
           secure: location.protocol === 'https:'
         };
-
-        var params = Avatar.options.defaultAvatarParams;
-
-        // defaultAvatarUrl takes precedence over params
-        if (!Avatar.options.defaultAvatarUrl && !_.isEmpty(params))
-          options = _.extend(options, params);
-        else
-          options.default = defaultUrl;
 
         user = getEmailOrHash(user); 
         // error if emailHashProperty is set but value is undefined


### PR DESCRIPTION
I was looking through the default gravatar options and I noticed you can pass in special parameters to the url to get different avatars, like the one StackOverflow uses for example. I added an option to pass in default gravatar parameters via a 'defaultAvatarParams' property to make this easier, since I noticed the Gravatar.imageUrl function pretty much already implemented the logic required. The options I'm talking about are the ones [here](https://secure.gravatar.com/site/implement/images/#default-image). 

Oh, and since the Gravatar package does some string operations, if you happened to pass in an undefined value into Gravatar.imageUrl, an error would be printed to the console. A possible scenario might be if the emailHashPropery is set in config, but the user hash property didn't exist. I added a simple check to make sure that this doesn't happen, and return the defaultUrl if Gravatar.imageUrl fails.

Great package by the way!
