### PR TITLE
Added avatar initials as fallback

### DIFF
--- a/export.js
+++ b/export.js
@@ -19,12 +19,45 @@ Avatar = {
     gravatarDefault: ''
   },
 
+  // Get the initials of the user
+  getInitials: function (user) {
+    var initials = "";
+
+    if(!user) {
+      return;
+    }
+
+    if(user.profile && user.profile.firstName) {
+      initials = user.profile.firstName.charAt(0).toUpperCase();
+
+      if(user.profile.lastName) {
+        initials += user.profile.lastName.charAt(0).toUpperCase();
+      }
+      else if(user.profile.familyName) {
+        initials += user.profile.familyName.charAt(0).toUpperCase();
+      }
+      else if(user.profile.secondName) {
+        initials += user.profile.secondName.charAt(0).toUpperCase();
+      }
+      else if(user.profile.name) {
+        initials += user.profile.name.charAt(0).toUpperCase();
+      }
+    }
+    else if(user.profile && user.profile.name) {
+      user.profile.name.split(" ").forEach(function(part){
+        initials += part.charAt(0).toUpperCase();
+      });
+    }
+
+    return initials ? initials : null;
+  },
+
   // Get the url of the user's avatar
   getUrl: function (user) {
 
     var url, defaultUrl;
 
-    defaultUrl = Avatar.options.defaultAvatarUrl || 'packages/bengott_avatar/default.png';
+    defaultUrl = Avatar.options.defaultAvatarUrl;
 
     // If it's a relative path (no '//' anywhere), complete the URL
     if (defaultUrl.indexOf('//') === -1) {
@@ -54,10 +87,12 @@ Avatar = {
         url = user.services.instagram.profile_picture;
       }
       else if (svc === 'none') {
-        var gravatarDefault;
         var validGravatars = ['404', 'mm', 'identicon', 'monsterid', 'wavatar', 'retro', 'blank'];
         if (_.contains(validGravatars, Avatar.options.gravatarDefault)) {
           gravatarDefault = Avatar.options.gravatarDefault;
+        }
+        else {
+          gravatarDefault = '404';
         }
 
         var options = {
@@ -70,7 +105,7 @@ Avatar = {
           secure: location.protocol === 'https:'
         };
 
-        var emailOrHash = getEmailOrHash(user); 
+        var emailOrHash = getEmailOrHash(user);
         url = emailOrHash && Gravatar.imageUrl(emailOrHash, options) || defaultUrl;
       }
     } else {

--- a/template/avatar.html
+++ b/template/avatar.html
@@ -1,3 +1,7 @@
 <template name="avatar">
-  <img src="{{url}}" class="{{class}}" />
+        {{#if hasImage}}
+            <img src="{{avatar.url}}" class="{{class}}" />
+        {{else}}
+            <span class="{{class}}" style="{{style}}">{{avatar.initials}}</span>
+        {{/if}}
 </template>

--- a/template/avatar.js
+++ b/template/avatar.js
@@ -1,12 +1,10 @@
 Template.avatar.helpers({
-  
-  url: function () {
-    var user;
-    if      (this.user)   { user = this.user; }
-    else if (this.userId) { user = Meteor.users.findOne(this.userId); }
-    return Avatar.getUrl(user);
+
+  hasImage: function() {
+    Template.instance().hasImageDep.depend();
+    return Template.instance().hasImage
   },
-  
+
   // If the input {{class}} string is empty or contains only modifier
   // classes ('large', 'rounded', 'circle'), return 'avatar ' + {{class}}.
   // Otherwise, the input string is custom CSS, so return it unmodified. This
@@ -16,7 +14,7 @@ Template.avatar.helpers({
     // Support {{cssClass}} for backward compatibility
     input = (this.cssClass && !this.class) ? this.cssClass : this.class;
     if (input) {
-      var mods = ['large', 'rounded', 'circle'];
+      var mods = ['large', 'small', 'rounded', 'circle'];
       var classes = input.split(' ');
       var onlyMods = _.every(classes, function (c) { return _.contains(mods, c); });
       output = (onlyMods) ? 'avatar ' + input : input;  
@@ -24,6 +22,54 @@ Template.avatar.helpers({
       output = 'avatar';
     }
     return output;
-  }
+  },
 
+  style: function() {
+    var style;
+
+    if(this.background) {
+      style = "background: " + this.background + ";";
+    }
+    if(this.color) {
+      style += "color: " + this.color + ";";
+    }
+
+    return style;
+  },
+
+  avatar: function () {
+    var user;
+
+    if (this.user) {
+      user = this.user;
+    }
+    else if (this.userId) {
+      user = Meteor.users.findOne(this.userId);
+    }
+
+    return {
+      initials: this.initials ? this.initials : Avatar.getInitials(user),
+      url: Avatar.getUrl(user)
+    };
+  }
 });
+
+Template.avatar.created = function() {
+  this.hasImage = true;
+  this.hasImageDep = new Deps.Dependency();
+};
+
+Template.avatar.rendered = function onRendered() {
+  var self = this;
+  var avatar = $('.avatar');
+
+  avatar.on('error', function onError(){
+    self.hasImage = false;
+    self.hasImageDep.changed();
+  });
+
+  avatar.on('load', function onLoad(){
+    self.hasImage = true;
+    self.hasImageDep.changed();
+  });
+};

--- a/template/avatar.styl
+++ b/template/avatar.styl
@@ -5,6 +5,12 @@
   width 40px
   background-size 100% 100%
   display block
+  background #aaa
+  color #fff
+  font-size 14px
+  text-align center
+  font-family "Helvetica Neue", Helvetica, "Hiragino Sans GB", Arial, sans-serif
+  line-height 40px
 
   &.rounded
     border-radius 5px
@@ -15,3 +21,11 @@
   &.large
     height 80px
     width 80px
+    font-size 27px
+    line-height 80px
+
+  &.small
+    height 30px
+    width 30px
+    font-size 12px
+    line-height 30px

--- a/versions.json
+++ b/versions.json
@@ -6,7 +6,7 @@
     ],
     [
       "blaze",
-      "2.0.2"
+      "2.0.3-rc.0"
     ],
     [
       "deps",
@@ -50,11 +50,11 @@
     ],
     [
       "meteor",
-      "1.1.2"
+      "1.1.3-rc.0"
     ],
     [
       "minimongo",
-      "1.0.4"
+      "1.0.5-rc.0"
     ],
     [
       "observe-sequence",
@@ -78,7 +78,7 @@
     ],
     [
       "templating",
-      "1.0.8"
+      "1.0.9-rc.1"
     ],
     [
       "tracker",
@@ -90,6 +90,6 @@
     ]
   ],
   "pluginDependencies": [],
-  "toolVersion": "meteor-tool@1.0.34",
+  "toolVersion": "meteor-tool@1.0.35-rc.7",
   "format": "1.0"
 }


### PR DESCRIPTION
This PR adds the functionality to show an "initials avatar" as fallback when no "image avatar" could be loaded. The logic is that in case that an avatar image url cannot be loaded (404), the template will show the initials of the user instead. This means that the initials will only show if no defaultAvatarUrl or gravatarDefault has been set, or if the image url is invalid / cannot be loaded for any reason and returns a 404.

The appearance of the initials are defined in the CSS and '"background" and "color" can be overridden in the template call if wanted:

{{> avatar user=currentUser class="circle small" background="#563d7c" color="#fff"}}

I have additionally added a "small" class in addition to the existing "large" class.

The getAvatar method tries to resolve the user´s initials from the profile field (tries combinations of firstName, lastName, familyName etc. if they exits), but can also be set directly in the template call like this:

{{> avatar user=currentUser initials="MA"}}
