### PR TITLE
Fix the "user" undefined error message

### DIFF
--- a/export.js
+++ b/export.js
@@ -59,6 +59,10 @@ Avatar = {
   // Get the url of the user's avatar
   getUrl: function (user) {
 
+    if (typeof user == 'undefined') {
+      return;
+    }
+
     var defaultUrl = Avatar.options.defaultImageUrl || 'packages/bengott_avatar/default.png';
     // If it's a relative path (no '//' anywhere), complete the URL
     if (defaultUrl.indexOf('//') === -1) {


### PR DESCRIPTION
Avatars for users that haven't yet been published generate an annoying error message since the user object is undefined while waiting for the subscription to be fully pushed.

This test fixes that.
