### PR TITLE
Materialize compatibility

### DIFF
--- a/template/avatar.html
+++ b/template/avatar.html
@@ -1,6 +1,6 @@
 <template name="avatar">
-  <div class="avatar {{size}} {{shape}} {{hideClass}} {{class}}">
-    <img class="avatar-image" src="{{imageUrl}}" {{dimensions}} alt="avatar" />
-    <span class="avatar-initials" style="{{initialsCss}}">{{initialsText}}</span>
+  <div class="ma-avatar {{size}} {{shape}} {{hideClass}} {{class}}">
+    <img class="ma-avatar-image" src="{{imageUrl}}" {{dimensions}} alt="ma-avatar" />
+    <span class="ma-avatar-initials" style="{{initialsCss}}">{{initialsText}}</span>
   </div>
 </template>

--- a/template/avatar.js
+++ b/template/avatar.js
@@ -2,7 +2,7 @@ Template.avatar.helpers({
 
   size: function () {
     var valid = ['large', 'small', 'extra-small'];
-    return _.contains(valid, this.size) ? 'avatar-' + this.size : '';
+    return _.contains(valid, this.size) ? 'ma-avatar-' + this.size : '';
   },
 
   dimensions: function () {
@@ -17,14 +17,14 @@ Template.avatar.helpers({
 
   shape: function () {
     var valid = ['rounded', 'circle'];
-    return _.contains(valid, this.shape) ? 'avatar-' + this.shape : '';
+    return _.contains(valid, this.shape) ? 'ma-avatar-' + this.shape : '';
   },
 
   hideClass: function () {
     // If image loaded successfully, hide initials and show image.
     // Otherwise, hide image and show initials.
     var hasImage = Template.instance().hasImage.get();
-    return hasImage ? 'avatar-hide-initials' : 'avatar-hide-image';
+    return hasImage ? 'ma-avatar-hide-initials' : 'ma-avatar-hide-image';
   },
 
   class: function () { return this.class; },

--- a/template/avatar.styl
+++ b/template/avatar.styl
@@ -1,14 +1,14 @@
 @import "nib"
 
-.avatar
+.ma-avatar
   height 50px
   width 50px
 
-  .avatar-image, .avatar-initials
+  .ma-avatar-image, .ma-avatar-initials
     height 100%
     width 100%
 
-  .avatar-initials
+  .ma-avatar-initials
     display block
     background-size 100% 100%
     background-color #aaa
@@ -18,39 +18,39 @@
     font-family "Helvetica Neue", Helvetica, "Hiragino Sans GB", Arial, sans-serif
     text-align center
 
-.avatar-large
+.ma-avatar-large
   height 80px
   width 80px
-  .avatar-initials
+  .ma-avatar-initials
     font-size 40px
     line-height 80px
 
-.avatar-small
+.ma-avatar-small
   height 30px
   width 30px
-  .avatar-initials
+  .ma-avatar-initials
     font-size 15px
     line-height 30px
 
-.avatar-extra-small
+.ma-avatar-extra-small
   height 20px
   width 20px
-  .avatar-initials
+  .ma-avatar-initials
     font-size 10px
     line-height 20px
 
-.avatar-rounded
-  .avatar-image, .avatar-initials
+.ma-avatar-rounded
+  .ma-avatar-image, .ma-avatar-initials
     border-radius 5px
 
-.avatar-circle
-  .avatar-image, .avatar-initials
+.ma-avatar-circle
+  .ma-avatar-image, .ma-avatar-initials
     border-radius 50%
 
-.avatar-hide-image
-  .avatar-image
+.ma-avatar-hide-image
+  .ma-avatar-image
     display none
 
-.avatar-hide-initials
-  .avatar-initials
+.ma-avatar-hide-initials
+  .ma-avatar-initials
     display none


### PR DESCRIPTION
Some UI frameworks define .avatar (e.g. Materialize). By prefixing css
classes with ma-, we can make avatar compatible with Materialize and 
add a little future proofing to  the avatar package.
