### PR TITLE
Remove onerror handler

### DIFF
--- a/template/avatar.html
+++ b/template/avatar.html
@@ -1,6 +1,6 @@
 <template name="avatar">
   <div class="avatar {{size}} {{shape}} {{class}}">
-    <img class="avatar-image" src="{{imageUrl}}" {{dimensions}} alt="avatar" onerror="this.style.display='none';" />
+    <img class="avatar-image" src="{{imageUrl}}" {{dimensions}} alt="avatar" />
     <span class="avatar-initials" style="{{initialsCss}}">{{initialsText}}</span>
   </div>
 </template>


### PR DESCRIPTION
I'd rather have the errors show up in my console. Also allows for slightly-more-likely-to-work avatars loading after userId change or whatever.

While using this for a toy app, it began to really bug me that I couldn't see why the image wouldn't display. I'm aware that this breaks falling back to initials - however, surely it would be better to explicitly handle this elsewhere, rather than in the template?

Anyway, I'd be surprised if you merged this. I just forked it so I could use it myself, and thought I may as well put in the PR. Can give a better rationale if you really actually care.
