### PR TITLE
Remove 'display: none' when reactivity is trying to get image again

### DIFF
--- a/template/avatar.js
+++ b/template/avatar.js
@@ -24,7 +24,11 @@ Template.avatar.helpers({
 
   imageUrl: function () {
     var user = this.user ? this.user : Meteor.users.findOne(this.userId);
-    return Avatar.getUrl(user);
+    var url = Avatar.getUrl(user);
+    if (url && url.trim() !== '' && Template.instance().firstNode) {
+      Template.instance().find('img').style.removeProperty('display');
+    }
+    return url;
   },
 
   initialsCss: function () {


### PR DESCRIPTION
If you have user's _id before subscribe user's data, the avatar’s lib isn't removing "display none" even if user received a valid email or external service url.