### PR TITLE
Only remove 'display' if url changes

### DIFF
--- a/template/avatar.js
+++ b/template/avatar.js
@@ -26,7 +26,10 @@ Template.avatar.helpers({
     var user = this.user ? this.user : Meteor.users.findOne(this.userId);
     var url = Avatar.getUrl(user);
     if (url && url.trim() !== '' && Template.instance().firstNode) {
-      Template.instance().find('img').style.removeProperty('display');
+      var img = Template.instance().find('img');
+      if (img.src !== url.trim()) {
+        img.style.removeProperty('display');
+      }
     }
     return url;
   },


### PR DESCRIPTION
We realized that if user have an invalid gravatar email and the user's record changes my old solution removes the display: none but meteor doesn't reset img src and the error callback don't will be called.

So now I'm testing if url changes before remove display: none to prevent this behavior.

Sorry about that and please accept this PR.

Thanks